### PR TITLE
Menu Title Fix

### DIFF
--- a/game/sourcemod/scripting/donationcontrol.sp
+++ b/game/sourcemod/scripting/donationcontrol.sp
@@ -65,7 +65,7 @@ public void OnConfigsExecuted()
 		}
 
 		hDisplayMenu = new Menu(MenuHandle);
-		hDisplayMenu.SetTitle("%s", "Menu Title");
+		hDisplayMenu.SetTitle("%t", "Menu Title");
 		hDisplayMenu.AddItem("5", "5");
 		hDisplayMenu.AddItem("10", "10");
 		hDisplayMenu.AddItem("15", "15");
@@ -132,7 +132,7 @@ public Action DonatePanel(int client, int args)
 
 public int MenuHandle(Menu menu, MenuAction action, int param1, int param2)
 {
-	switch(action)
+	switch (action)
 	{
 		case MenuAction_Select:
 		{


### PR DESCRIPTION
I accidentally made the menu title use the parameter '%s' instead of the correct one '%t'. Actually, it might have been there by default, can't remember. Either way, here is the fix.